### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ See [here a demo](http://rawgit.com/jonataswalker/timepicker.js/master/examples/
 ##### CDN Hosted - [jsDelivr](http://www.jsdelivr.com/projects/timepicker.js)
 Load CSS and Javascript:
 ```HTML
-<link href="//cdn.jsdelivr.net/timepicker.js/latest/timepicker.min.css"  rel="stylesheet">
-<script src="//cdn.jsdelivr.net/timepicker.js/latest/timepicker.min.js"></script>
+<link href="//cdn.jsdelivr.net/npm/timepicker.js@latest/build/timepicker.min.css"  rel="stylesheet">
+<script src="//cdn.jsdelivr.net/npm/timepicker.js@latest/build/timepicker.min.js"></script>
 ```
 ##### Self hosted
 Download [latest release](https://github.com/jonataswalker/timepicker.js/releases/latest) and (obviously) load CSS and Javascript.


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/timepicker.js.

Feel free to ping me if you have any questions regarding this change.